### PR TITLE
Brush-ups

### DIFF
--- a/plan01s_jp/switch-carrier.sh
+++ b/plan01s_jp/switch-carrier.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 switch_plmn()
 {
     # NOTE: this parameter should be different with the countries the SIM connects.
-    current_plmn=$(mmcli -m 0 | grep "operator id" | awk '{print substr($0, index($0, "440"))}')
+    current_plmn=$(mmcli -m 0 | grep -oP "(?<=operator id: )\d+")
     echo "The modem connects to the PLMN ${current_plmn}"
 
     # NOTE: this parameter should be different with the supported PLMN of SIM or module.
@@ -29,7 +29,7 @@ switch_plmn()
     nmcli con up soracom
 
     # NOTE: this parameter should be different with the countries the SIM connects.
-    final_plmn=$(mmcli -m 0 | grep "operator id" | awk '{print substr($0, index($0, "440"))}')
+    final_plmn=$(mmcli -m 0 | grep -oP "(?<=operator id: )\d+")
     echo "The modem switched to the PLMN ${final_plmn}"
 
     exit 0
@@ -44,7 +44,7 @@ then
 fi
 
 count=${COUNT:-10}
-ping_loss_rate=$(ping 8.8.8.8 -c "$count" -I wwan0 | grep "packet loss" | awk -F ' ' '{print $6}')
+ping_loss_rate=$(ping 8.8.8.8 -c "$count" -I wwan0 | grep -oP "\d+%(?= packet loss)")
 
 if [ "$ping_loss_rate" = "" ]
 then


### PR DESCRIPTION
いくつか brush up しました。

- `sudo` を使ってルート権限で実行するように促すエラーメッセージ中にスクリプトのファイル名がハードコードされていましたが、[d08af53](https://github.com/soracom-labs/multi-carrier-demo/pull/1/commits/d08af536e4b5ea2f6fe5d8a8d311906d5d8ff055) ではそれを `$0` という特別なパラメータ（実行されているスクリプトのファイル名自体が入っている）を使うようにしました。これにより、たとえば `./plan01s_jp/switch-carrier.sh` というようにこのスクリプトを実行した人には、エラーメッセージが
    ```
    $ ./plan01s_jp/switch-carrier.sh 
    You must run this script as root. Please try again using "sudo ./plan01s_jp/switch-carrier.sh"
    ```
    というふうに表示されるようになります。

- `PING_SEND_NUMBER` という変数に固定値の 10 が入れられていましたが、[2f81231](https://github.com/soracom-labs/multi-carrier-demo/pull/1/commits/2f81231ed6aaa06c79e5304f62c0cf3a1a76067b) ではユーザーがその値をオーバーライドできるようにしました。また、スクリプトの外部から受け取る変数名は全て大文字、内部でのみ利用する変数は全て小文字で記述することで役割が多少明確になるので私はそのルールを好んで適用していますのでこちらでも適用させてもらいました。それから、何かの回数とか個数を表す変数名には number ではなく count を使う方が意味が明確になりますので変数名を変更しました。Code complete からの受け売りですが、number だと番号という意味もあったりして曖昧になりがちなので。さらに、変数名が長かったので短く単に `COUNT` ( `count` ) としました。`PING_COUNT` とかでも良いかもしれませんが、このくらいの規模のスクリプトであれば十分明確なので `COUNT` で良いと思います。将来的にスクリプトが成長して複雑になってきたら Be right a lot するかもしれません。
  なお、Ping の送信回数をオーバーライドするには、コミットのコメントにも書きましたが `COUNT=5 ./switch-carrier.sh` という感じで実行します。

- `mmcli` や `ping` の実行結果をパースするのに `grep` と `awk` を組み合わせて目的の値を取り出していますが、grep の Look ahead や Look behind という機能を使うと `grep` だけでそれが実現できますので https://github.com/soracom-labs/multi-carrier-demo/pull/1/commits/c8b596dcdea92140d0a1fa645781a7ff70fc1b61 で対応しました。一応簡単な動作確認は行ないましたが mick の方でも期待した挙動になっているかご確認いただければと思います。

- ファイルに実行権限が付いていませんでしたが [9c62f40](https://github.com/soracom-labs/multi-carrier-demo/pull/1/commits/9c62f409cf2429ee9a802534c9d0e82cc50a08a2) で付与しました。

- 空行の空白を削除、ファイル末尾の改行を追加しました（フォーマッタが）https://github.com/soracom-labs/multi-carrier-demo/pull/1/commits/c8764db4a0e11522b6f014204d538861cbcb0a43
