### PR TITLE
run ShellCheck by GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,13 @@
+name: test
+
+on: push
+
+jobs:
+  test:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout codes
+        uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![test](https://github.com/soracom-labs/multi-carrier-demo/workflows/test/badge.svg)](https://github.com/soracom-labs/multi-carrier-demo/actions/workflows/test.yaml)
+
 # Multi Carrier Demo
 
 ## Overview


### PR DESCRIPTION
GitHub Actions で ShellCheck をキックするようにしました。
ShellCheck でエラー検出時は以下のような形で CI に失敗するようになります。

```
Notice: ./plan01s_jp/switch-carrier.sh:38:6: note: Double quote to prevent globbing and word splitting. [SC2086]
Run echo "Files: ./plan01s_jp/switch-carrier.sh"
  echo "Files: ./plan01s_jp/switch-carrier.sh"
  echo "Excluded: ! -path "*./.git/*" ! -path "*.go" ! -path "*/mvnw""
  echo "Options: --format=gcc"
  echo "Status code: 1"
  
  exit 1
```

ref. https://github.com/soracom-labs/multi-carrier-demo/runs/7622158647?check_suite_focus=true#step:3:151
