### PR TITLE
Catch exception for ping

### DIFF
--- a/plan01s_jp/switch-carrier.sh
+++ b/plan01s_jp/switch-carrier.sh
@@ -6,7 +6,7 @@ switch_plmn()
     # NOTE: this parameter should be different with the countries the SIM connects.
     current_plmn=$(mmcli -m 0 | grep -oP "(?<=operator id: )\d+")
     echo "The modem connects to the PLMN ${current_plmn}"
-    
+
     # NOTE: this parameter should be different with the supported PLMN of SIM or module.
     if [ "$current_plmn" = "44010" ]
     then
@@ -14,24 +14,24 @@ switch_plmn()
     else
         target_plmn=44010
     fi
-    
+
     echo "The script will switch the PLMN to ${target_plmn}"
-    
+
     echo "Terminate the Cellular connection..."
     nmcli con down soracom
     sleep 10
-    
+
     echo "Switch the carrier..."
     mmcli -m 0 --3gpp-register-in-operator=${target_plmn}
     sleep 10
-    
+
     echo "Start the new Cellular connection with PLMN ${target_plmn}..."
     nmcli con up soracom
-    
+
     # NOTE: this parameter should be different with the countries the SIM connects.
     final_plmn=$(mmcli -m 0 | grep -oP "(?<=operator id: )\d+")
     echo "The modem switched to the PLMN ${final_plmn}"
-    
+
     exit 0
 }
 


### PR DESCRIPTION
https://github.com/soracom-labs/multi-carrier-demo/blob/main/plan01s_jp/switch-carrier.sh#L2 にて `set -Eeuo pipefail` をつけると、ping ロス率 100% の時に以下の終了ステータスが 1 になってしまい、スクリプトが終了してしまうことわかりました。

```
ping 8.8.8.8 -c "$count" -I wwan0 | grep -oP "\d+%(?= packet loss)"
```

ping のときだけ status code 1 を許容するように変更したいです。